### PR TITLE
Improve exception handling in get_user_info

### DIFF
--- a/raven/contrib/django/client.py
+++ b/raven/contrib/django/client.py
@@ -140,17 +140,18 @@ class DjangoClient(Client):
         install_sql_hook()
 
     def get_user_info(self, user):
-        if hasattr(user, 'is_authenticated'):
-            # is_authenticated was a method in Django < 1.10
-            if callable(user.is_authenticated):
-                authenticated = user.is_authenticated()
-            else:
-                authenticated = user.is_authenticated
-            if not authenticated:
-                return None
-
-        user_info = {}
         try:
+            if hasattr(user, 'is_authenticated'):
+                # is_authenticated was a method in Django < 1.10
+                if callable(user.is_authenticated):
+                    authenticated = user.is_authenticated()
+                else:
+                    authenticated = user.is_authenticated
+                if not authenticated:
+                    return None
+
+            user_info = {}
+        
             user_info['id'] = user.pk
 
             if hasattr(user, 'email'):


### PR DESCRIPTION
The original code might break, e.g. when `user` is an instance of `django.utils.functional.SimpleLazyObject` and its `_setup` raises exception.

We need to make sure the exception gets reported regardless of the user info availability.